### PR TITLE
fix: add env_file configuration for frontend services in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,8 @@ services:
       dockerfile: Dockerfile
     container_name: react_frontend_web
     restart: unless-stopped
+    env_file:
+      - .env
     environment:
       - CHOKIDAR_USEPOLLING=true
     volumes:
@@ -81,6 +83,8 @@ services:
       dockerfile: Dockerfile
     container_name: react_frontend_admin
     restart: unless-stopped
+    env_file:
+      - .env
     environment:
       - CHOKIDAR_USEPOLLING=true
     volumes:
@@ -98,6 +102,8 @@ services:
       dockerfile: Dockerfile
     container_name: react_frontend_ecoponto
     restart: unless-stopped
+    env_file:
+      - .env
     environment:
       - CHOKIDAR_USEPOLLING=true
     volumes:


### PR DESCRIPTION
Google API for login feature requires a secret key. To handle this securely, the configuration has been updated to load the secret key from an .env file and reference it through environment variables in the frontend code