### PR TITLE
fix: add email duplicate and new password validation 

### DIFF
--- a/backend/src/core/infrastructure/serializers/user_serializers.py
+++ b/backend/src/core/infrastructure/serializers/user_serializers.py
@@ -53,8 +53,14 @@ class UserSerializer(serializers.ModelSerializer):
         """
         Verify that email is unique.
         """
-        # Check if email already exists (case-insensitive)
-        if User.objects.filter(email__iexact=email).exists():
+        ## Check if email already exists (case-insensitive)
+        queryset = User.objects.filter(email__iexact=email)
+        
+        # Exclude current instance during updates
+        if self.instance:
+            queryset = queryset.exclude(pk=self.instance.pk)
+        
+        if queryset.exists():
             raise serializers.ValidationError("Email already exists.")
         
         return email

--- a/backend/src/core/infrastructure/serializers/user_serializers.py
+++ b/backend/src/core/infrastructure/serializers/user_serializers.py
@@ -49,6 +49,16 @@ class UserSerializer(serializers.ModelSerializer):
         instance.save()
         return instance
  
+    def validate_email(self, email):
+        """
+        Verify that email is unique.
+        """
+        # Check if email already exists (case-insensitive)
+        if User.objects.filter(email__iexact=email).exists():
+            raise serializers.ValidationError("Email already exists.")
+        
+        return email
+
     def validate_cpf(self, cpf):
         """
         Verify CPF format: XXX.XXX.XXX-XX.

--- a/backend/src/core/presentation/api/user_view.py
+++ b/backend/src/core/presentation/api/user_view.py
@@ -241,8 +241,14 @@ class UserViewSet(viewsets.ModelViewSet):
         if new != confirm:
             return Response({"error": "New password and confirmation do not match."}, status=status.HTTP_400_BAD_REQUEST)
 
-        if not new or len(new) < 6:
-            return Response({"error": "New password must be at least 6 characters long."}, status=status.HTTP_400_BAD_REQUEST)
+        if not new or len(new) < 8:
+            return Response({"error": "Password must have at least 8 characters."}, status=status.HTTP_400_BAD_REQUEST)
+
+        if not any(char.isdigit() for char in new):
+            return Response({"error": "Password must contains at least one number"}, status=status.HTTP_400_BAD_REQUEST)
+
+        if not any(char.isupper() for char in new):
+            return Response({"error": "Password must have at least one capitalized letter"}, status=status.HTTP_400_BAD_REQUEST)
 
         user.set_password(new)
         user.save()


### PR DESCRIPTION
This PR implements email duplicate verification, avoiding creating users with the same e-mail, and new password validation, preveting users using passwords without at least one capital letter and one number

The only edited file is `user_serializers.py`.